### PR TITLE
Nathan tinkering

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ from torch.utils.data import DataLoader
 #   - the difference in time of the feature delay/offset and the "0" offset (the feature with the least delay).
 # NOTE: As a result of the above, at least one of the elements in the tuple will be always 0, which makes it useless.
 #       This approach however gives freedom when there are non-trivial delay relations between different sets of features.
-for control, _, state, state_delay, target, target_delay in Dataloader(dataset):
+for control, _, state, state_delay, target, target_delay in DataLoader(dataset):
     # In this case control_delay is always 0, so we just ignore it.
     pass
 ```

--- a/README.md
+++ b/README.md
@@ -113,12 +113,6 @@ There are also additional scripts:
 * look_at_dists - A script that can be used to look at the distribution of the training data.
 * unit_tests - Script that can perform some controlled tests given a scripted model. TODO: These should not be here I think. Ideally we should just have tests folder for dynamics modeling.
 
-TODO: Do we have the following?
-
-Ideally should be some command-line thing like `python3 train.py path/to/rosbags/directory path/to/params/file` where the params file contains things like learning rate, model architecture, the reader / filters to use, and so forth. Then it saves the model as something like `<directory_name>_<params_filename>.pt` (and saves the learning curves and qualitative results and such). Should probably also copy the params file into the model save directory as read-only, for future reference.
-
-Running a hyperparameter search would be a different script.
-
 ## Development
 From this point on-ward are instructions and other resources for the development.
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ There are also additional scripts:
 * look_at_dists - A script that can be used to look at the distribution of the training data.
 * unit_tests - Script that can perform some controlled tests given a scripted model. TODO: These should not be here I think. Ideally we should just have tests folder for dynamics modeling.
 
+TODO: Do we have the following?
+
+Ideally should be some command-line thing like `python3 train.py path/to/rosbags/directory path/to/params/file` where the params file contains things like learning rate, model architecture, the reader / filters to use, and so forth. Then it saves the model as something like `<directory_name>_<params_filename>.pt` (and saves the learning curves and qualitative results and such). Should probably also copy the params file into the model save directory as read-only, for future reference.
+
+Running a hyperparameter search would be a different script.
+
 ## Development
 From this point on-ward are instructions and other resources for the development.
 

--- a/examples/hidden2relu.py
+++ b/examples/hidden2relu.py
@@ -71,7 +71,7 @@ def train(
 def main():
     DELAY_STEPS = 15
     EPOCHS = 50
-    TRAIN = True
+    TRAIN = False
     PLOT_VAL = True
     PLOT_LEN_ROLLOUT = 10  # seconds
 
@@ -90,15 +90,14 @@ def main():
         ["control", "state", "target"],
         log_interval=1 / 30.,
         filters=[
-            filters.BackwardFilter(),
+            filters.ForwardFilter(),
+            filters.PIDInfoFilter()
         ]
     )
 
-    sequences = load_bags("/home/nhatch2/Downloads/racer_data/sim_dynamics_backwards", reader)
-    train_sequences = sequences[0:3] + sequences[4:8]
-    val_sequences = sequences[3:4] + sequences[8:9]
+    val_sequences = load_bags("datasets/rzr_real_val", reader)
 
-    model_name = f"models/sim_backward.pt"
+    model_name = f"models/example_hidden2relu_delay_{DELAY_STEPS}_model.pt"
 
 
     if TRAIN:
@@ -112,6 +111,7 @@ def main():
         optimizer = optim.Adam(model.parameters(), weight_decay=0.01)
         criterion = nn.MSELoss()
 
+        train_sequences = load_bags("datasets/rzr_real", reader)
         train_dataset = LookaheadDataset(train_sequences, ["control", "state"], ["target"], delay_steps=DELAY_STEPS)
 
         val_dataset = LookaheadDataset(val_sequences, ["control", "state"], ["target"], delay_steps=DELAY_STEPS)
@@ -163,7 +163,7 @@ def main():
             plt.title("Predicted velocity Displacement (acc./model output * dt)")
             if not os.path.exists("plots"):
                 os.makedirs("plots")
-            plt.savefig(f"plots/sim_backward_plots.png")
+            plt.savefig(f"plots/dx_dtheta_pred_delay_{DELAY_STEPS}.png")
             plt.show()
 
             # Convert from (dx, dtheta) to (dx, dy, dtheta)
@@ -240,7 +240,7 @@ def main():
             plt.ylabel("y (m)")
             if not os.path.exists("plots"):
                 os.makedirs("plots")
-            plt.savefig(f"plots/sim_backwards_qualitative.png")
+            plt.savefig(f"plots/hidden2relu_delay_{DELAY_STEPS}_rollout.png")
             plt.show()
 
 

--- a/examples/hidden2relu.py
+++ b/examples/hidden2relu.py
@@ -71,7 +71,7 @@ def train(
 def main():
     DELAY_STEPS = 15
     EPOCHS = 50
-    TRAIN = False
+    TRAIN = True
     PLOT_VAL = True
     PLOT_LEN_ROLLOUT = 10  # seconds
 
@@ -90,14 +90,15 @@ def main():
         ["control", "state", "target"],
         log_interval=1 / 30.,
         filters=[
-            filters.ForwardFilter(),
-            filters.PIDInfoFilter()
+            filters.BackwardFilter(),
         ]
     )
 
-    val_sequences = load_bags("datasets/rzr_real_val", reader)
+    sequences = load_bags("/home/nhatch2/Downloads/racer_data/sim_dynamics_backwards", reader)
+    train_sequences = sequences[0:3] + sequences[4:8]
+    val_sequences = sequences[3:4] + sequences[8:9]
 
-    model_name = f"models/example_hidden2relu_delay_{DELAY_STEPS}_model.pt"
+    model_name = f"models/sim_backward.pt"
 
 
     if TRAIN:
@@ -111,7 +112,6 @@ def main():
         optimizer = optim.Adam(model.parameters(), weight_decay=0.01)
         criterion = nn.MSELoss()
 
-        train_sequences = load_bags("datasets/rzr_real", reader)
         train_dataset = LookaheadDataset(train_sequences, ["control", "state"], ["target"], delay_steps=DELAY_STEPS)
 
         val_dataset = LookaheadDataset(val_sequences, ["control", "state"], ["target"], delay_steps=DELAY_STEPS)
@@ -163,7 +163,7 @@ def main():
             plt.title("Predicted velocity Displacement (acc./model output * dt)")
             if not os.path.exists("plots"):
                 os.makedirs("plots")
-            plt.savefig(f"plots/dx_dtheta_pred_delay_{DELAY_STEPS}.png")
+            plt.savefig(f"plots/sim_backward_plots.png")
             plt.show()
 
             # Convert from (dx, dtheta) to (dx, dy, dtheta)
@@ -240,7 +240,7 @@ def main():
             plt.ylabel("y (m)")
             if not os.path.exists("plots"):
                 os.makedirs("plots")
-            plt.savefig(f"plots/hidden2relu_delay_{DELAY_STEPS}_rollout.png")
+            plt.savefig(f"plots/sim_backwards_qualitative.png")
             plt.show()
 
 

--- a/examples/sequence_model.py
+++ b/examples/sequence_model.py
@@ -360,12 +360,10 @@ def main():
     rollout_len = int(ROLLOUT_S  * log_hz)
 
     val_sequences = load_bags(DATASET_VAL, reader)
-    val_sequences = val_sequences[5:6] + val_sequences[8:9]
     val_dataset = SequenceLookaheadDataset(
         val_sequences, [("control", 0), ("state", 3), ("target", 4)], sequence_length=rollout_len
     )
     train_sequences = load_bags(DATASET_TRAIN, reader)
-    train_sequences = train_sequences[0:5] + train_sequences[6:8]
     train_dataset = SequenceLookaheadDataset(
         train_sequences, [("control", 0), ("state", 3), ("target", 4)], sequence_length=rollout_len
     )

--- a/src/rosbag2torch/bag_processing/bag_processing.py
+++ b/src/rosbag2torch/bag_processing/bag_processing.py
@@ -17,10 +17,17 @@ def load_bags(
         Sequences: A list of sequences (each is a dictionary) extracted from the bag files.
             Note that one bag may contain any number of sequences (0, 1, or more).
     """
-    for file_path in Path(data_folder).rglob("*.bag"):
+    p = Path(data_folder)
+    if not p.is_dir():
+        raise NotADirectoryError("{} is not a directory".format(data_folder))
+
+    for file_path in p.rglob("*.bag"):
         reader.extract_bag_data(file_path)
 
     sequences = reader.sequences
     reader.reset()
+
+    if len(sequences) == 0:
+        print("Warning: reader found no sequences in {}".format(data_folder))
 
     return sequences

--- a/src/rosbag2torch/bag_processing/bag_processing.py
+++ b/src/rosbag2torch/bag_processing/bag_processing.py
@@ -29,5 +29,7 @@ def load_bags(
 
     if len(sequences) == 0:
         print("Warning: reader found no sequences in {}".format(data_folder))
+    else:
+        print("Found {} sequences".format(len(sequences)))
 
     return sequences

--- a/src/rosbag2torch/bag_processing/bag_processing.py
+++ b/src/rosbag2torch/bag_processing/bag_processing.py
@@ -30,6 +30,7 @@ def load_bags(
     if len(sequences) == 0:
         print("Warning: reader found no sequences in {}".format(data_folder))
     else:
-        print("Found {} sequences".format(len(sequences)))
+        print("Found {} sequences of len {}".format(
+            len(sequences), list(map(lambda s: len(s["time"]), sequences))))
 
     return sequences

--- a/src/rosbag2torch/datasets/torch_sequence_lookahead.py
+++ b/src/rosbag2torch/datasets/torch_sequence_lookahead.py
@@ -38,6 +38,11 @@ class SequenceLookaheadDataset(Dataset):
         self.__sequence_start_idxs = np.cumsum([0] + self.__sequence_lengths[:-1])
         # Total number of rollouts in all sequences
         self.__total_len = sum(self.__sequence_lengths)
+        seq_len_string = "+".join(map(lambda i: str(i), self.__sequence_lengths))
+        print(f"Constructed dataset of size {self.__total_len} ({seq_len_string})")
+        if self.__total_len == 0:
+            print("ERROR: empty dataset")
+            from IPython import embed; embed()
 
     def __len__(self) -> int:
         """Number of rollouts/sequences in this dataset.


### PR DESCRIPTION
* Changes to error messaging (e.g. when loading caches)
* Fixed bug with computing average loss over entire epoch
* Decreased rollout length to 1 second (instead of 5 seconds) in sequence_model.py

The rollout length thing is a longer discussion, but basically if we set it to 5 seconds, then any sequences shorter than 5 seconds are completely ignored. This is a fairly important problem, because most of our backwards-mode driving is done as part of a K turn, where the time in motion is indeed less than 5 seconds. I think the long-term solution here is to support training on sequences of various lengths, rather than requiring them all to be exactly the same. But that's a larger change. In the meantime, I think using a 1-second rollout length should be sufficient to get reasonably good dynamics models, even for short backward sequences during K turns.